### PR TITLE
Add option to generate a user agent substring for the given components

### DIFF
--- a/Source/Bridge.swift
+++ b/Source/Bridge.swift
@@ -29,6 +29,11 @@ public final class Bridge: Bridgable {
         }
     }
     
+    public static func userAgentSubstring(for componentTypes: [BridgeComponent.Type]) -> String {
+        let components = componentTypes.map { $0.name }.joined(separator: " ")
+        return "bridge-components: [\(components)]"
+    }
+    
     init(webView: WKWebView) {
         self.webView = webView
         loadIntoWebView()
@@ -37,7 +42,7 @@ public final class Bridge: Bridgable {
     deinit {
         webView?.configuration.userContentController.removeScriptMessageHandler(forName: scriptHandlerName)
     }
-
+    
     // MARK: - Internal API
     
     /// Register a single component

--- a/Tests/BridgeTests.swift
+++ b/Tests/BridgeTests.swift
@@ -114,6 +114,16 @@ class BridgeTests: XCTestCase {
         
         waitForExpectations(timeout: 2)
     }
+    
+    func testUserAgentSubstringWithTwoComponents() {
+        let userAgentSubstring = Bridge.userAgentSubstring(for: [OneBridgeComponent.self, TwoBridgeComponent.self])
+        XCTAssertEqual(userAgentSubstring, "bridge-components: [one two]")
+    }
+    
+    func testUserAgentSubstringWithNoComponents() {
+        let userAgentSubstring = Bridge.userAgentSubstring(for: [])
+        XCTAssertEqual(userAgentSubstring, "bridge-components: []")
+    }
 }
 
 private final class TestWebView: WKWebView {
@@ -123,4 +133,24 @@ private final class TestWebView: WKWebView {
         lastEvaluatedJavaScript = javaScriptString
         super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
     }
+}
+
+private class OneBridgeComponent: BridgeComponent {
+    static override var name: String { "one" }
+    
+    required init(destination: BridgeDestination, delegate: BridgeDelegate) {
+        super.init(destination: destination, delegate: delegate)
+    }
+    
+    override func handle(message: Strada.Message) {}
+}
+
+private class TwoBridgeComponent: BridgeComponent {
+    static override var name: String { "two" }
+    
+    required init(destination: BridgeDestination, delegate: BridgeDelegate) {
+        super.init(destination: destination, delegate: delegate)
+    }
+    
+    override func handle(message: Strada.Message) {}
 }


### PR DESCRIPTION
This PR adds a built-in way for the library to produce a user-agent substring that apps can include in their WebView user-agent and API requests.

Apps can obtain the user-agent string by calling:

`Bridge.userAgentSubstring(for: [OneBridgeComponent.self, TwoBridgeComponent.self])`

It will produce a string that looks like:

`"bridge-components: [one two three four]"`