### PR TITLE
Avoid accessing the bridge directly from within the BridgeComponent.

### DIFF
--- a/Source/BridgeComponent.swift
+++ b/Source/BridgeComponent.swift
@@ -37,13 +37,7 @@ open class BridgeComponent: BridgingComponent {
     /// - Parameter message: The message to be replied with.
     /// - Returns: `true` if the reply was successful, `false` if the bridge is not available.
     public func reply(with message: Message) -> Bool {
-        guard let bridge = delegate.bridge else {
-            logger.warning("bridgeMessageFailedToReply: bridge is not available")
-            return false
-        }
-        
-        bridge.reply(with: message)
-        return true
+        return delegate.reply(with: message)
     }
     
     @discardableResult

--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -34,6 +34,21 @@ public final class BridgeDelegate {
         bridge = nil
     }
     
+    @discardableResult
+    /// Replies to the web with a received message, optionally replacing its `event` or `jsonData`.
+    ///
+    /// - Parameter message: The message to be replied with.
+    /// - Returns: `true` if the reply was successful, `false` if the bridge is not available.
+    public func reply(with message: Message) -> Bool {
+        guard let bridge else {
+            logger.warning("bridgeMessageFailedToReply: bridge is not available")
+            return false
+        }
+        
+        bridge.reply(with: message)
+        return true
+    }
+    
     // MARK: - Destination lifecycle
     
     public func onViewDidLoad() {

--- a/Tests/BridgeDelegateTests.swift
+++ b/Tests/BridgeDelegateTests.swift
@@ -141,6 +141,28 @@ class BridgeDelegateTests: XCTestCase {
         XCTAssertTrue(delegate.bridgeDidReceiveMessage(testMessage()))
     }
     
+    // MARK: reply(with:)
+   
+    func test_replyWithSucceedsWhenBridgeIsSet() {
+        let message = testMessage()
+        let success = delegate.reply(with: message)
+        
+        XCTAssertTrue(success)
+        XCTAssertTrue(bridge.replyWithMessageWasCalled)
+        XCTAssertEqual(bridge.replyWithMessageArg, message)
+    }
+    
+    func test_replyWithFailsWhenBridgeNotSet() {
+        delegate.bridge = nil
+
+        let message = testMessage()
+        let success = delegate.reply(with: message)
+
+        XCTAssertFalse(success)
+        XCTAssertFalse(bridge.replyWithMessageWasCalled)
+        XCTAssertNil(bridge.replyWithMessageArg)
+    }
+    
     private func testMessage() -> Message {
         return Message(id: "1",
                        component: "two",


### PR DESCRIPTION
This PR adds `reply(with:)` function to `BridgeDelegate` to avoid accessing the bridge directly from within the `BridgeComponent`.

This is prerequisite work for enabling component message testing.