### PR TITLE
Get web view's URL at runtime

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,24 +4,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-on: 
+on:
   push:
     branches:
     - main
   pull_request:
 
-env:
-  XCODEBUILD_DESTINATION_IOS: 'platform=iOS Simulator,name=iPhone 15 Pro'
-
 jobs:
   build-and-test:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_14.2.app && /usr/bin/xcodebuild -version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: Run Tests
-        run: xcodebuild test -project Strada.xcodeproj -scheme Strada -destination "${{ env.XCODEBUILD_DESTINATION_IOS }}" -resultBundlePath TestResults
+        run: xcodebuild test -scheme Strada -destination "name=iPhone 15 Pro" | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
 
 env:
-  XCODEBUILD_DESTINATION_IOS: 'platform=iOS Simulator,name=iPhone 14 Pro'
+  XCODEBUILD_DESTINATION_IOS: 'platform=iOS Simulator,name=iPhone 15 Pro'
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Strada iOS
 
-**[Strada](https://strada.hotwired.dev)** lets you create high fidelity native features driven by your web app. It's a set of libraries that work across your [web](https://github.com/hotwired/strada-web), [Android](https://github.com/hotwired/strada-android), and iOS apps to help you build features that make your [Turbo Native](https://turbo.hotwired.dev/handbook/native) hybrid apps stand out. Turn HTML elements that exist in the WebView into native components and communicate messages across your native and web code.
+**[Strada](https://strada.hotwired.dev)** lets you create fully native controls, driven by your web app. It's a set of libraries that work across your [web](https://github.com/hotwired/strada-web), [Android](https://github.com/hotwired/strada-android), and iOS apps to help you build features that make your [Turbo Native](https://turbo.hotwired.dev/handbook/native) hybrid apps stand out. Turn HTML elements that exist in the WebView into native components and communicate messages across your native and web code.
 
 **Strada iOS** enables you to create native components that receive and reply to messages from web components that are present on the page. Native components receive messages to run native code, whether it's to build high fidelity native UI or call platform APIs.
 

--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -117,7 +117,7 @@ public final class BridgeDelegate: BridgingDelegate {
     @discardableResult
     public func bridgeDidReceiveMessage(_ message: Message) -> Bool {
         guard destinationIsActive,
-              location == message.metadata?.url else {
+              webView?.url?.absoluteString ?? location == message.metadata?.url else {
             logger.warning("bridgeDidIgnoreMessage: \(String(describing: message))")
             return false
         }

--- a/Tests/MessageTests.swift
+++ b/Tests/MessageTests.swift
@@ -184,7 +184,7 @@ class MessageTests: XCTestCase {
     
     // MARK: Custom encoding
     
-    func test_encodingWithCustomEncoder() {
+    func test_encodingWithCustomEncoder() throws {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         Strada.config.jsonEncoder = encoder
@@ -204,6 +204,15 @@ class MessageTests: XCTestCase {
         
         let newMessage = message.replacing(data: messageData)
         
-        XCTAssertEqual(message, newMessage)
+        XCTAssertEqual(message.id, newMessage.id)
+        XCTAssertEqual(message.event, newMessage.event)
+        XCTAssertEqual(message.metadata, newMessage.metadata)
+
+        // JSON as a string might have keys in a different order. Parse values to ensure equality.
+        let newMessageData = try XCTUnwrap(message.jsonData.jsonObject() as? [String: String])
+        XCTAssertEqual(newMessageData.keys.count, 3)
+        XCTAssertEqual(newMessageData["title"], "Page-title")
+        XCTAssertEqual(newMessageData["subtitle"], "Page-subtitle")
+        XCTAssertEqual(newMessageData["action_name"], "go")
     }
 }

--- a/Tests/MessageTests.swift
+++ b/Tests/MessageTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import Strada
+@testable import Strada
 
 class MessageTests: XCTestCase {
     


### PR DESCRIPTION
If a Turbo request is redirected to a page with a Strada component this check would always fail. `location` is only set when `BridgeDelegate` is initialized. This change dynamically grabs the URL from the web view, falling back to the original `location` if nil.

Fixes #23 and should also address part of #19.