### PR TITLE
Fix race condition when setting up Strada components

### DIFF
--- a/Source/strada.js
+++ b/Source/strada.js
@@ -12,7 +12,7 @@
     }
     
     async setAdapter() {
-      await this.registerCalled;
+      await this.registerCalled
       this.webBridge.setAdapter(this)
     }
 

--- a/Source/strada.js
+++ b/Source/strada.js
@@ -13,7 +13,7 @@
     
     async setAdapter() {
       await this.registerCalled;
-      this.webBridge.setAdapter(this);
+      this.webBridge.setAdapter(this)
     }
 
     register(component) {

--- a/Source/strada.js
+++ b/Source/strada.js
@@ -5,7 +5,15 @@
   class NativeBridge {
     constructor() {
       this.supportedComponents = []
-      document.addEventListener("web-bridge:ready", () => this.webBridge.setAdapter(this))
+      this.registerCalled = new Promise(resolve => this.registerResolver = resolve)
+      document.addEventListener("web-bridge:ready", async () => {
+        await this.setAdapter()
+      })
+    }
+    
+    async setAdapter() {
+      await this.registerCalled;
+      this.webBridge.setAdapter(this);
     }
 
     register(component) {
@@ -15,6 +23,7 @@
         this.supportedComponents.push(component)
       }
 
+      this.registerResolver()
       this.notifyBridgeOfSupportedComponentsUpdate()
     }
 


### PR DESCRIPTION
There is a race condition that has been discussed in #20. The symptom is that messages aren't received in the native adapter from Strada JS components after pulling to refresh.

### Racer 1

The JS shim is injected `.atDocumentStart`
https://github.com/hotwired/strada-ios/blob/d8c1bcf1d9511c03e7beed07c05d29f33f9b6cde/Source/Bridge.swift#L147

`ready` message is posted to the native adapter
https://github.com/hotwired/strada-ios/blob/d8c1bcf1d9511c03e7beed07c05d29f33f9b6cde/Source/strada.js#L70-L71

It goes through the Swift code and eventually calls `register` to set the `supportedComponents`
https://github.com/hotwired/strada-ios/blob/d8c1bcf1d9511c03e7beed07c05d29f33f9b6cde/Source/strada.js#L11-L19


### Racer 2

strada-web dispatches `web-bridge: ready`
https://github.com/hotwired/strada-web/blob/df1c2b40234286dad55815aaf78b31f8691693e9/src/bridge.js#L18-L20

The native app calls `setAdapter` upon receiving that event
https://github.com/hotwired/strada-ios/blob/d8c1bcf1d9511c03e7beed07c05d29f33f9b6cde/Source/strada.js#L8

Once the adapter is set, strada-web is free to send messages. Before it sends a message it calls `supportsComponent`.
https://github.com/hotwired/strada-ios/blob/d8c1bcf1d9511c03e7beed07c05d29f33f9b6cde/Source/strada.js#L35-L37


### Solution

Racer 1 is setting `supportedComponents` and Racer 2 requires it to already be set. The two racers aren't correlated and either path can get there first.

I think something like this PR is the best way to solve it. It's `NativeBridge`'s responsibility to be fully set up before calling `setAdapter`.

I'm not a JS dev and used AI ✨ to help me write a Promise. Tell me or just change it if you think there is a better way.