### PR TITLE
Async javascript take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.xcuserstate
 *.xcbkptlist
 .swiftpm
+xcuserdata

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 build
 node_modules
 *.log
-
 *.xcuserstate
-
 *.xcbkptlist
+.swiftpm

--- a/Source/Bridge.swift
+++ b/Source/Bridge.swift
@@ -8,11 +8,11 @@ public enum BridgeError: Error {
 protocol Bridgable: AnyObject {
     var delegate: BridgeDelegate? { get set }
     var webView: WKWebView? { get }
-    
-    func register(component: String) async
-    func register(components: [String]) async
-    func unregister(component: String) async
-    func reply(with message: Message) async
+
+    func register(component: String) async throws
+    func register(components: [String]) async throws
+    func unregister(component: String) async throws
+    func reply(with message: Message) async throws
 }
 
 /// `Bridge` is the object for configuring a web view and
@@ -22,50 +22,50 @@ public final class Bridge: Bridgable {
 
     weak var delegate: BridgeDelegate?
     weak var webView: WKWebView?
-    
+
     public static func initialize(_ webView: WKWebView) {
         if getBridgeFor(webView) == nil {
             initialize(Bridge(webView: webView))
         }
     }
-    
+
     init(webView: WKWebView) {
         self.webView = webView
         loadIntoWebView()
     }
-    
+
     deinit {
         webView?.configuration.userContentController.removeScriptMessageHandler(forName: scriptHandlerName)
     }
-    
+
     // MARK: - Internal API
-    
+
     /// Register a single component
     /// - Parameter component: Name of a component to register support for
-    func register(component: String) async {
-        await callBridgeFunction(.register, arguments: [component])
+    func register(component: String) async throws {
+        try await callBridgeFunction(.register, arguments: [component])
     }
-    
+
     /// Register multiple components
     /// - Parameter components: Array of component names to register
-    func register(components: [String]) async {
-        await callBridgeFunction(.register, arguments: [components])
+    func register(components: [String]) async throws {
+        try await callBridgeFunction(.register, arguments: [components])
     }
-    
+
     /// Unregister support for a single component
     /// - Parameter component: Component name
-    func unregister(component: String) async {
-        await callBridgeFunction(.unregister, arguments: [component])
+    func unregister(component: String) async throws {
+        try await callBridgeFunction(.unregister, arguments: [component])
     }
-    
+
     /// Send a message through the bridge to the web application
     /// - Parameter message: Message to send
-    func reply(with message: Message) async {
+    func reply(with message: Message) async throws {
         logger.debug("bridgeWillReplyWithMessage: \(String(describing: message))")
         let internalMessage = InternalMessage(from: message)
-        await callBridgeFunction(.replyWith, arguments: [internalMessage.toJSON()])
+        try await callBridgeFunction(.replyWith, arguments: [internalMessage.toJSON()])
     }
-    
+
 //    /// Convenience method to reply to a previously received message. Data will be replaced,
 //    /// while id, component, and event will remain the same
 //    /// - Parameter message: Message to reply to
@@ -76,28 +76,24 @@ public final class Bridge: Bridgable {
 //    }
     @MainActor
     @discardableResult
-    func evaluate(javaScript: String) async -> JavaScriptResult {
+    func evaluate(javaScript: String) async throws -> Any? {
         guard let webView = webView else {
-            return JavaScriptResult(result: nil, error: BridgeError.missingWebView)
+            throw BridgeError.missingWebView
         }
 
-        var result: Any? = nil
-        var error: Error? = nil
         do {
-            result = try await webView.evaluateJavaScript(javaScript)
-        } catch let e {
-            logger.error("Error evaluating JavaScript: \(e)")
-            error = e
+            return try await webView.evaluateJavaScript(javaScript)
+        } catch {
+            logger.error("Error evaluating JavaScript: \(error)")
+            throw error
         }
-
-        return JavaScriptResult(result: result, error: error)
     }
 
     /// Evaluates a JavaScript function with optional arguments by encoding the arguments
     /// Function should not include the parens
     /// Usage: evaluate(function: "console.log", arguments: ["test"])
-    func evaluate(function: String, arguments: [Any] = []) async -> JavaScriptResult {
-        await evaluate(javaScript: JavaScript(functionName: function, arguments: arguments))
+    func evaluate(function: String, arguments: [Any] = []) async throws -> Any? {
+        try await evaluate(javaScript: JavaScript(functionName: function, arguments: arguments).toString())
     }
 
     static func initialize(_ bridge: Bridge) {
@@ -108,23 +104,23 @@ public final class Bridge: Bridgable {
     static func getBridgeFor(_ webView: WKWebView) -> Bridge? {
         return instances.first { $0.webView == webView }
     }
-    
+
     // MARK: Private
 
     private static var instances: [Bridge] = []
     /// This needs to match whatever the JavaScript file uses
     private let bridgeGlobal = "window.nativeBridge"
-    
+
     /// The webkit.messageHandlers name
     private let scriptHandlerName = "strada"
-    
-    private func callBridgeFunction(_ function: JavaScriptBridgeFunction, arguments: [Any]) async {
+
+    private func callBridgeFunction(_ function: JavaScriptBridgeFunction, arguments: [Any]) async throws {
         let js = JavaScript(object: bridgeGlobal, functionName: function.rawValue, arguments: arguments)
-        await evaluate(javaScript: js)
+        try await evaluate(javaScript: js)
     }
 
     // MARK: - Configuration
-    
+
     /// Configure the bridge in the provided web view
     private func loadIntoWebView() {
         guard let configuration = webView?.configuration else { return }
@@ -133,17 +129,18 @@ public final class Bridge: Bridgable {
         if let userScript = makeUserScript() {
             configuration.userContentController.addUserScript(userScript)
         }
-        
+
         let scriptMessageHandler = ScriptMessageHandler(delegate: self)
         configuration.userContentController.add(scriptMessageHandler, name: scriptHandlerName)
     }
 
     private func makeUserScript() -> WKUserScript? {
         guard
-            let path = PathLoader().pathFor(name: "strada", fileType: "js") else {
-                return nil
+            let path = PathLoader().pathFor(name: "strada", fileType: "js")
+        else {
+            return nil
         }
-        
+
         do {
             let source = try String(contentsOfFile: path)
             return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: true)
@@ -152,16 +149,16 @@ public final class Bridge: Bridgable {
             return nil
         }
     }
-    
+
     // MARK: - JavaScript Evaluation
-    
+
     @discardableResult
-    private func evaluate(javaScript: JavaScript) async -> JavaScriptResult {
+    private func evaluate(javaScript: JavaScript) async throws -> Any? {
         do {
-            return await evaluate(javaScript: try javaScript.toString())
+            return try await evaluate(javaScript: javaScript.toString())
         } catch {
             logger.error("Error evaluating JavaScript: \(String(describing: javaScript)), error: \(error)")
-            return JavaScriptResult(result: nil, error: error)
+            throw error
         }
     }
 
@@ -174,25 +171,17 @@ public final class Bridge: Bridgable {
 
 extension Bridge: ScriptMessageHandlerDelegate {
     @MainActor
-    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage) async {
-        if let event = scriptMessage.body as? String,
-            event == "ready" {
-            await delegate?.bridgeDidInitialize()
+    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage) async throws {
+        if let event = scriptMessage.body as? String, event == "ready" {
+            try await delegate?.bridgeDidInitialize()
             return
         }
-        
+
         if let message = InternalMessage(scriptMessage: scriptMessage) {
             delegate?.bridgeDidReceiveMessage(message.toMessage())
             return
         }
-        
-        logger.warning("Unhandled message received: \(String(describing: scriptMessage.body))")
-    }
-}
 
-extension Bridge {
-    struct JavaScriptResult {
-        let result: Any?
-        let error: Error?
+        logger.warning("Unhandled message received: \(String(describing: scriptMessage.body))")
     }
 }

--- a/Source/Bridge.swift
+++ b/Source/Bridge.swift
@@ -74,7 +74,7 @@ public final class Bridge: Bridgable {
 //        let replyMessage = message.replacing(data: data)
 //        callBridgeFunction("send", arguments: [replyMessage.toJSON()])
 //    }
-
+    @MainActor
     @discardableResult
     func evaluate(javaScript: String) async -> JavaScriptResult {
         guard let webView = webView else {
@@ -173,6 +173,7 @@ public final class Bridge: Bridgable {
 }
 
 extension Bridge: ScriptMessageHandlerDelegate {
+    @MainActor
     func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage) async {
         if let event = scriptMessage.body as? String,
             event == "ready" {

--- a/Source/BridgeComponent.swift
+++ b/Source/BridgeComponent.swift
@@ -58,7 +58,10 @@ open class BridgeComponent: BridgingComponent {
 
     /// Replies to the web with a received message, optionally replacing its `event` or `jsonData`.
     ///
-    /// - Parameter message: The message to be replied with.
+    /// - Parameters:
+    ///     - message: The message to be replied with.
+    ///     - completion: An optional completion handler to be called when the reply attempt completes.
+    ///                   It includes a result indicating whether the reply was successful or not.
     public func reply(with message: Message, completion: ReplyCompletionHandler? = nil) {
         Task {
             do {
@@ -90,7 +93,10 @@ open class BridgeComponent: BridgingComponent {
     ///
     /// NOTE: If a message has not been received for the given `event`, the reply will be ignored.
     ///
-    /// - Parameter event: The `event` for which a reply should be sent.
+    /// - Parameters:
+    ///     - event: The `event` for which a reply should be sent.
+    ///     - completion: An optional completion handler to be called when the reply attempt completes.
+    ///                   It includes a result indicating whether the reply was successful or not.
     public func reply(to event: String, completion: ReplyCompletionHandler? = nil) {
         Task {
             do {
@@ -121,6 +127,26 @@ open class BridgeComponent: BridgingComponent {
         return try await reply(with: messageReply)
     }
     
+    /// Replies to the web with the last received message for a given `event`, replacing its `jsonData`.
+    ///
+    /// NOTE: If a message has not been received for the given `event`, the reply will be ignored.
+    ///
+    /// - Parameters:
+    ///   - event: The `event` for which a reply should be sent.
+    ///   - jsonData: The `jsonData` to be included in the reply message.
+    ///   - completion: An optional completion handler to be called when the reply attempt completes.
+    ///                 It includes a result indicating whether the reply was successful or not.
+    public func reply(to event: String, with jsonData: String, completion: ReplyCompletionHandler? = nil) {
+        Task {
+            do {
+                let result = try await reply(to: event, with: jsonData)
+                completion?(.success((result)))
+            } catch {
+                completion?(.failure(error))
+            }
+        }
+    }
+    
     @discardableResult
     /// Replies to the web with the last received message for a given `event`, replacing its `jsonData`
     /// with the provided `Encodable` object. 
@@ -139,6 +165,27 @@ open class BridgeComponent: BridgingComponent {
         
         let messageReply = message.replacing(data: data)
         return try await reply(with: messageReply)
+    }
+    
+    /// Replies to the web with the last received message for a given `event`, replacing its `jsonData`
+    /// with the provided `Encodable` object.
+    ///
+    /// NOTE: If a message has not been received for the given `event`, the reply will be ignored.
+    ///
+    /// - Parameters:
+    ///   - event: The `event` for which a reply should be sent.
+    ///   - data: An instance conforming to `Encodable` to be included as `jsonData` in the reply message.
+    ///   - completion: An optional completion handler to be called when the reply attempt completes.
+    ///                 It includes a result indicating whether the reply was successful or not.
+    public func reply<T: Encodable>(to event: String, with data: T, completion: ReplyCompletionHandler? = nil) {
+        Task {
+            do {
+                let result = try await reply(to: event, with: data)
+                completion?(.success((result)))
+            } catch {
+                completion?(.failure(error))
+            }
+        }
     }
     
     /// Returns the last received message for a given `event`, if available.

--- a/Source/BridgeComponent.swift
+++ b/Source/BridgeComponent.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@MainActor
 protocol BridgingComponent: AnyObject {
     static var name: String { get }
     var delegate: BridgingDelegate { get }
@@ -22,6 +23,7 @@ protocol BridgingComponent: AnyObject {
     func viewDidDisappear()
 }
 
+@MainActor
 open class BridgeComponent: BridgingComponent {
     public typealias ReplyCompletionHandler = (Result<Bool, Error>) -> Void
 
@@ -30,7 +32,7 @@ open class BridgeComponent: BridgingComponent {
     /// Subclasses must provide their own implementation of this property.
     ///
     /// - Note: This property is used for identifying the component.
-    open class var name: String {
+    nonisolated open class var name: String {
         fatalError("BridgeComponent subclass must provide a unique 'name'")
     }
     
@@ -149,7 +151,7 @@ open class BridgeComponent: BridgingComponent {
     
     @discardableResult
     /// Replies to the web with the last received message for a given `event`, replacing its `jsonData`
-    /// with the provided `Encodable` object. 
+    /// with the provided `Encodable` object.
     ///
     /// NOTE: If a message has not been received for the given `event`, the reply will be ignored.
     ///
@@ -275,3 +277,4 @@ open class BridgeComponent: BridgingComponent {
     
     private var receivedMessages = [String: Message]()
 }
+

--- a/Source/BridgeComponent.swift
+++ b/Source/BridgeComponent.swift
@@ -50,8 +50,8 @@ open class BridgeComponent: BridgingComponent {
     ///
     /// - Parameter message: The message to be replied with.
     /// - Returns: `true` if the reply was successful, `false` if the bridge is not available.
-    public func reply(with message: Message) async -> Bool {
-        await delegate.reply(with: message)
+    public func reply(with message: Message) async throws -> Bool {
+        try await delegate.reply(with: message)
     }
     
     @discardableResult
@@ -61,13 +61,13 @@ open class BridgeComponent: BridgingComponent {
     ///
     /// - Parameter event: The `event` for which a reply should be sent.
     /// - Returns: `true` if the reply was successful, `false` if the event message was not received.
-    public func reply(to event: String) async -> Bool {
+    public func reply(to event: String) async throws -> Bool {
         guard let message = receivedMessage(for: event) else {
             logger.warning("bridgeMessageFailedToReply: message for event \(event) was not received")
             return false
         }
         
-        return await reply(with: message)
+        return try await reply(with: message)
     }
     
     @discardableResult
@@ -79,15 +79,14 @@ open class BridgeComponent: BridgingComponent {
     ///   - event: The `event` for which a reply should be sent.
     ///   - jsonData: The `jsonData` to be included in the reply message.
     /// - Returns: `true` if the reply was successful, `false` if the event message was not received.
-    public func reply(to event: String, with jsonData: String) async -> Bool {
+    public func reply(to event: String, with jsonData: String) async throws -> Bool {
         guard let message = receivedMessage(for: event) else {
             logger.warning("bridgeMessageFailedToReply: message for event \(event) was not received")
             return false
         }
         
         let messageReply = message.replacing(jsonData: jsonData)
-        
-        return await reply(with: messageReply)
+        return try await reply(with: messageReply)
     }
     
     @discardableResult
@@ -100,15 +99,14 @@ open class BridgeComponent: BridgingComponent {
     ///   - event: The `event` for which a reply should be sent.
     ///   - data: An instance conforming to `Encodable` to be included as `jsonData` in the reply message.
     /// - Returns: `true` if the reply was successful, `false` if the event message was not received.
-    public func reply<T: Encodable>(to event: String, with data: T) async -> Bool {
+    public func reply<T: Encodable>(to event: String, with data: T) async throws -> Bool {
         guard let message = receivedMessage(for: event) else {
             logger.warning("bridgeMessageFailedToReply: message for event \(event) was not received")
             return false
         }
         
         let messageReply = message.replacing(data: data)
-        
-        return await reply(with: messageReply)
+        return try await reply(with: messageReply)
     }
     
     /// Returns the last received message for a given `event`, if available.

--- a/Source/BridgeComponent.swift
+++ b/Source/BridgeComponent.swift
@@ -23,6 +23,8 @@ protocol BridgingComponent: AnyObject {
 }
 
 open class BridgeComponent: BridgingComponent {
+    public typealias ReplyCompletionHandler = (Result<Bool, Error>) -> Void
+
     /// A unique name representing the `BridgeComponent` type.
     ///
     /// Subclasses must provide their own implementation of this property.
@@ -57,8 +59,15 @@ open class BridgeComponent: BridgingComponent {
     /// Replies to the web with a received message, optionally replacing its `event` or `jsonData`.
     ///
     /// - Parameter message: The message to be replied with.
-    public func reply(with message: Message) {
-        Task { _ = try await delegate.reply(with: message) }
+    public func reply(with message: Message, completion: ReplyCompletionHandler? = nil) {
+        Task {
+            do {
+                let result = try await delegate.reply(with: message)
+                completion?(.success((result)))
+            } catch {
+                completion?(.failure(error))
+            }
+        }
     }
 
     @discardableResult
@@ -82,8 +91,15 @@ open class BridgeComponent: BridgingComponent {
     /// NOTE: If a message has not been received for the given `event`, the reply will be ignored.
     ///
     /// - Parameter event: The `event` for which a reply should be sent.
-    public func reply(to event: String) {
-        Task { _ = try await reply(to: event) }
+    public func reply(to event: String, completion: ReplyCompletionHandler? = nil) {
+        Task {
+            do {
+                let result = try await reply(to: event)
+                completion?(.success((result)))
+            } catch {
+                completion?(.failure(error))
+            }
+        }
     }
 
     @discardableResult

--- a/Source/BridgeComponent.swift
+++ b/Source/BridgeComponent.swift
@@ -50,8 +50,8 @@ open class BridgeComponent: BridgingComponent {
     ///
     /// - Parameter message: The message to be replied with.
     /// - Returns: `true` if the reply was successful, `false` if the bridge is not available.
-    public func reply(with message: Message) -> Bool {
-        return delegate.reply(with: message)
+    public func reply(with message: Message) async -> Bool {
+        await delegate.reply(with: message)
     }
     
     @discardableResult
@@ -61,13 +61,13 @@ open class BridgeComponent: BridgingComponent {
     ///
     /// - Parameter event: The `event` for which a reply should be sent.
     /// - Returns: `true` if the reply was successful, `false` if the event message was not received.
-    public func reply(to event: String) -> Bool {
+    public func reply(to event: String) async -> Bool {
         guard let message = receivedMessage(for: event) else {
             logger.warning("bridgeMessageFailedToReply: message for event \(event) was not received")
             return false
         }
         
-        return reply(with: message)
+        return await reply(with: message)
     }
     
     @discardableResult
@@ -79,7 +79,7 @@ open class BridgeComponent: BridgingComponent {
     ///   - event: The `event` for which a reply should be sent.
     ///   - jsonData: The `jsonData` to be included in the reply message.
     /// - Returns: `true` if the reply was successful, `false` if the event message was not received.
-    public func reply(to event: String, with jsonData: String) -> Bool {
+    public func reply(to event: String, with jsonData: String) async -> Bool {
         guard let message = receivedMessage(for: event) else {
             logger.warning("bridgeMessageFailedToReply: message for event \(event) was not received")
             return false
@@ -87,7 +87,7 @@ open class BridgeComponent: BridgingComponent {
         
         let messageReply = message.replacing(jsonData: jsonData)
         
-        return reply(with: messageReply)
+        return await reply(with: messageReply)
     }
     
     @discardableResult
@@ -100,7 +100,7 @@ open class BridgeComponent: BridgingComponent {
     ///   - event: The `event` for which a reply should be sent.
     ///   - data: An instance conforming to `Encodable` to be included as `jsonData` in the reply message.
     /// - Returns: `true` if the reply was successful, `false` if the event message was not received.
-    public func reply<T: Encodable>(to event: String, with data: T) -> Bool {
+    public func reply<T: Encodable>(to event: String, with data: T) async -> Bool {
         guard let message = receivedMessage(for: event) else {
             logger.warning("bridgeMessageFailedToReply: message for event \(event) was not received")
             return false
@@ -108,7 +108,7 @@ open class BridgeComponent: BridgingComponent {
         
         let messageReply = message.replacing(data: data)
         
-        return reply(with: messageReply)
+        return await reply(with: messageReply)
     }
     
     /// Returns the last received message for a given `event`, if available.

--- a/Source/BridgeComponent.swift
+++ b/Source/BridgeComponent.swift
@@ -53,7 +53,14 @@ open class BridgeComponent: BridgingComponent {
     public func reply(with message: Message) async throws -> Bool {
         try await delegate.reply(with: message)
     }
-    
+
+    /// Replies to the web with a received message, optionally replacing its `event` or `jsonData`.
+    ///
+    /// - Parameter message: The message to be replied with.
+    public func reply(with message: Message) {
+        Task { _ = try await delegate.reply(with: message) }
+    }
+
     @discardableResult
     /// Replies to the web with the last received message for a given `event` with its original `jsonData`.
     ///
@@ -69,7 +76,16 @@ open class BridgeComponent: BridgingComponent {
         
         return try await reply(with: message)
     }
-    
+
+    /// Replies to the web with the last received message for a given `event` with its original `jsonData`.
+    ///
+    /// NOTE: If a message has not been received for the given `event`, the reply will be ignored.
+    ///
+    /// - Parameter event: The `event` for which a reply should be sent.
+    public func reply(to event: String) {
+        Task { _ = try await reply(to: event) }
+    }
+
     @discardableResult
     /// Replies to the web with the last received message for a given `event`, replacing its `jsonData`.
     ///

--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -21,7 +21,7 @@ public protocol BridgingDelegate: AnyObject {
     
     func component<C: BridgeComponent>() -> C?
     
-    func bridgeDidInitialize() async throws
+    func bridgeDidInitialize()
     func bridgeDidReceiveMessage(_ message: Message) -> Bool
 }
 
@@ -111,9 +111,15 @@ public final class BridgeDelegate: BridgingDelegate {
     
     // MARK: Internal use
     
-    public func bridgeDidInitialize() async throws {
+    public func bridgeDidInitialize() {
         let componentNames = componentTypes.map { $0.name }
-        try await bridge?.register(components: componentNames)
+        Task {
+            do {
+                try await bridge?.register(components: componentNames)
+            } catch {
+                logger.error("bridgeDidFailToRegisterComponents: \(error)")
+            }
+        }
     }
     
     @discardableResult

--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -10,7 +10,7 @@ public protocol BridgingDelegate: AnyObject {
     
     func webViewDidBecomeActive(_ webView: WKWebView)
     func webViewDidBecomeDeactivated()
-    func reply(with message: Message) async -> Bool
+    func reply(with message: Message) async throws -> Bool
 
     func onViewDidLoad()
     func onViewWillAppear()
@@ -20,7 +20,7 @@ public protocol BridgingDelegate: AnyObject {
     
     func component<C: BridgeComponent>() -> C?
     
-    func bridgeDidInitialize() async
+    func bridgeDidInitialize() async throws
     func bridgeDidReceiveMessage(_ message: Message) -> Bool
 }
 
@@ -60,13 +60,13 @@ public final class BridgeDelegate: BridgingDelegate {
     ///
     /// - Parameter message: The message to be replied with.
     /// - Returns: `true` if the reply was successful, `false` if the bridge is not available.
-    public func reply(with message: Message) async -> Bool {
+    public func reply(with message: Message) async throws -> Bool {
         guard let bridge else {
             logger.warning("bridgeMessageFailedToReply: bridge is not available")
             return false
         }
         
-        await bridge.reply(with: message)
+        try await bridge.reply(with: message)
         return true
     }
     
@@ -109,9 +109,9 @@ public final class BridgeDelegate: BridgingDelegate {
     
     // MARK: Internal use
     
-    public func bridgeDidInitialize() async {
+    public func bridgeDidInitialize() async throws {
         let componentNames = componentTypes.map { $0.name }
-        await bridge?.register(components: componentNames)
+        try await bridge?.register(components: componentNames)
     }
     
     @discardableResult

--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -3,6 +3,7 @@ import WebKit
 
 public protocol BridgeDestination: AnyObject {}
 
+@MainActor
 public protocol BridgingDelegate: AnyObject {
     var location: String { get }
     var destination: BridgeDestination { get }
@@ -24,6 +25,7 @@ public protocol BridgingDelegate: AnyObject {
     func bridgeDidReceiveMessage(_ message: Message) -> Bool
 }
 
+@MainActor
 public final class BridgeDelegate: BridgingDelegate {
     public let location: String
     public unowned let destination: BridgeDestination
@@ -153,4 +155,3 @@ public final class BridgeDelegate: BridgingDelegate {
         return component
     }
 }
-

--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -10,8 +10,8 @@ public protocol BridgingDelegate: AnyObject {
     
     func webViewDidBecomeActive(_ webView: WKWebView)
     func webViewDidBecomeDeactivated()
-    func reply(with message: Message) -> Bool
-    
+    func reply(with message: Message) async -> Bool
+
     func onViewDidLoad()
     func onViewWillAppear()
     func onViewDidAppear()
@@ -20,7 +20,7 @@ public protocol BridgingDelegate: AnyObject {
     
     func component<C: BridgeComponent>() -> C?
     
-    func bridgeDidInitialize()
+    func bridgeDidInitialize() async
     func bridgeDidReceiveMessage(_ message: Message) -> Bool
 }
 
@@ -60,13 +60,13 @@ public final class BridgeDelegate: BridgingDelegate {
     ///
     /// - Parameter message: The message to be replied with.
     /// - Returns: `true` if the reply was successful, `false` if the bridge is not available.
-    public func reply(with message: Message) -> Bool {
+    public func reply(with message: Message) async -> Bool {
         guard let bridge else {
             logger.warning("bridgeMessageFailedToReply: bridge is not available")
             return false
         }
         
-        bridge.reply(with: message)
+        await bridge.reply(with: message)
         return true
     }
     
@@ -109,9 +109,9 @@ public final class BridgeDelegate: BridgingDelegate {
     
     // MARK: Internal use
     
-    public func bridgeDidInitialize() {
+    public func bridgeDidInitialize() async {
         let componentNames = componentTypes.map { $0.name }
-        bridge?.register(components: componentNames)
+        await bridge?.register(components: componentNames)
     }
     
     @discardableResult

--- a/Source/Message.swift
+++ b/Source/Message.swift
@@ -31,9 +31,6 @@ public struct Message: Equatable {
         self.metadata = metadata
         self.jsonData = jsonData
     }
-    
-    /// Used to compare `jsonData` Strings.
-    private static let equalityJSONEncoder = JSONEncoder()
 }
 
 extension Message {
@@ -99,8 +96,8 @@ extension Message {
 }
 
 extension Message {
-    
-    /// Using `Equatable`'s default implementation is bound to give us false positives since two `Message`s may have semantically equal, but textually different, `jsonData`.
+    /// Using `Equatable`'s default implementation is bound to give us false positives
+    /// since two `Message`s may have semantically equal, but textually different, `jsonData`.
     ///
     /// For example, the following `jsonData` should be considered equal.
     ///
@@ -115,19 +112,10 @@ extension Message {
     ///   - rhs: another message
     /// - Returns: true if they're semantically equal
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        
-        if lhs.jsonData != rhs.jsonData {
-            guard let lhsJSONData = lhs.jsonData.data(using: .utf8),
-                  let rhsJSONData = rhs.jsonData.data(using: .utf8),
-                  let lhsJSONObject = try? JSONSerialization.jsonObject(with: lhsJSONData, options: []) as? NSObject,
-                  let rhsJSONObject = try? JSONSerialization.jsonObject(with: rhsJSONData, options: []) as? NSObject,
-                  lhsJSONObject == rhsJSONObject
-            else { return false }
-        }
-        
         return lhs.id == rhs.id &&
         lhs.component == rhs.component &&
         lhs.event == rhs.event &&
-        lhs.metadata == rhs.metadata
+        lhs.metadata == rhs.metadata &&
+        lhs.jsonData.jsonObject() as? [String: AnyHashable] == rhs.jsonData.jsonObject() as? [String: AnyHashable]
     }
 }

--- a/Source/Message.swift
+++ b/Source/Message.swift
@@ -31,6 +31,9 @@ public struct Message: Equatable {
         self.metadata = metadata
         self.jsonData = jsonData
     }
+    
+    /// Used to compare `jsonData` Strings.
+    private static let equalityJSONEncoder = JSONEncoder()
 }
 
 extension Message {
@@ -92,5 +95,39 @@ extension Message {
         public init(url: String) {
             self.url = url
         }
+    }
+}
+
+extension Message {
+    
+    /// Using `Equatable`'s default implementation is bound to give us false positives since two `Message`s may have semantically equal, but textually different, `jsonData`.
+    ///
+    /// For example, the following `jsonData` should be considered equal.
+    ///
+    /// ```
+    /// lhs.jsonData = "{\"title\":\"Page-title\",\"subtitle\":\"Page-subtitle\",\"action_name\":\"go\"}")"
+    ///
+    /// rhs.jsonData = "{\"action_name\":\"go\",\"title\":\"Page-title\",\"subtitle\":\"Page-subtitle\"}")"
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - lhs: a message
+    ///   - rhs: another message
+    /// - Returns: true if they're semantically equal
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        
+        if lhs.jsonData != rhs.jsonData {
+            guard let lhsJSONData = lhs.jsonData.data(using: .utf8),
+                  let rhsJSONData = rhs.jsonData.data(using: .utf8),
+                  let lhsJSONObject = try? JSONSerialization.jsonObject(with: lhsJSONData, options: []) as? NSObject,
+                  let rhsJSONObject = try? JSONSerialization.jsonObject(with: rhsJSONData, options: []) as? NSObject,
+                  lhsJSONObject == rhsJSONObject
+            else { return false }
+        }
+        
+        return lhs.id == rhs.id &&
+        lhs.component == rhs.component &&
+        lhs.event == rhs.event &&
+        lhs.metadata == rhs.metadata
     }
 }

--- a/Source/ScriptMessageHandler.swift
+++ b/Source/ScriptMessageHandler.swift
@@ -1,7 +1,7 @@
 import WebKit
 
 protocol ScriptMessageHandlerDelegate: AnyObject {
-    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage)
+    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage) async
 }
 
 // Avoids retain cycle caused by WKUserContentController
@@ -13,6 +13,6 @@ final class ScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
     
     func userContentController(_ userContentController: WKUserContentController, didReceive scriptMessage: WKScriptMessage) {
-        delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage)
+        Task { await delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage) }
     }
 }

--- a/Source/ScriptMessageHandler.swift
+++ b/Source/ScriptMessageHandler.swift
@@ -1,7 +1,7 @@
 import WebKit
 
 protocol ScriptMessageHandlerDelegate: AnyObject {
-    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage) async
+    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage) async throws
 }
 
 // Avoids retain cycle caused by WKUserContentController
@@ -13,6 +13,6 @@ final class ScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
     
     func userContentController(_ userContentController: WKUserContentController, didReceive scriptMessage: WKScriptMessage) {
-        Task { await delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage) }
+        Task { try await delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage) }
     }
 }

--- a/Source/ScriptMessageHandler.swift
+++ b/Source/ScriptMessageHandler.swift
@@ -1,7 +1,7 @@
 import WebKit
 
 protocol ScriptMessageHandlerDelegate: AnyObject {
-    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage) async throws
+    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage)
 }
 
 // Avoids retain cycle caused by WKUserContentController
@@ -13,6 +13,6 @@ final class ScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
     
     func userContentController(_ userContentController: WKUserContentController, didReceive scriptMessage: WKScriptMessage) {
-        Task { try await delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage) }
+        delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage)
     }
 }

--- a/Strada.xcodeproj/project.pbxproj
+++ b/Strada.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		E2DB15912A7163B0001EE08C /* BridgeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DB15902A7163B0001EE08C /* BridgeDelegate.swift */; };
 		E2DB15932A7282CF001EE08C /* BridgeComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DB15922A7282CF001EE08C /* BridgeComponent.swift */; };
 		E2DB15952A72B0A8001EE08C /* BridgeDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DB15942A72B0A8001EE08C /* BridgeDelegateTests.swift */; };
+		E2F4E06B2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F4E06A2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift */; };
 		E2FDCF982A8297DA003D27AE /* BridgeComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FDCF972A8297DA003D27AE /* BridgeComponentTests.swift */; };
 		E2FDCF9B2A829AEE003D27AE /* BridgeSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FDCF9A2A829AEE003D27AE /* BridgeSpy.swift */; };
 		E2FDCF9D2A829C6F003D27AE /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FDCF9C2A829C6F003D27AE /* TestData.swift */; };
@@ -79,6 +80,7 @@
 		E2DB15902A7163B0001EE08C /* BridgeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeDelegate.swift; sourceTree = "<group>"; };
 		E2DB15922A7282CF001EE08C /* BridgeComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeComponent.swift; sourceTree = "<group>"; };
 		E2DB15942A72B0A8001EE08C /* BridgeDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeDelegateTests.swift; sourceTree = "<group>"; };
+		E2F4E06A2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ExpectationTimeout.swift"; sourceTree = "<group>"; };
 		E2FDCF972A8297DA003D27AE /* BridgeComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeComponentTests.swift; sourceTree = "<group>"; };
 		E2FDCF9A2A829AEE003D27AE /* BridgeSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeSpy.swift; sourceTree = "<group>"; };
 		E2FDCF9C2A829C6F003D27AE /* TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
@@ -146,6 +148,7 @@
 		9274F1F22229963B003E85F4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E2F4E0692B9095A5000A3A24 /* Extensions */,
 				E227FAF12A94D48C00A645E4 /* ComponentTestExample */,
 				E2FDCF9C2A829C6F003D27AE /* TestData.swift */,
 				E2FDCF992A829AD5003D27AE /* Spies */,
@@ -179,6 +182,14 @@
 				E227FAF22A94D57300A645E4 /* ComposerComponentTests.swift */,
 			);
 			path = ComponentTestExample;
+			sourceTree = "<group>";
+		};
+		E2F4E0692B9095A5000A3A24 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E2F4E06A2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		E2FDCF992A829AD5003D27AE /* Spies */ = {
@@ -327,6 +338,7 @@
 			files = (
 				E2DB15952A72B0A8001EE08C /* BridgeDelegateTests.swift in Sources */,
 				E227FAF02A94D34E00A645E4 /* ComposerComponent.swift in Sources */,
+				E2F4E06B2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift in Sources */,
 				E227FAEE2A94B35900A645E4 /* BridgeDelegateSpy.swift in Sources */,
 				C11349C2258801F6000A6E56 /* JavaScriptTests.swift in Sources */,
 				E227FAF32A94D57300A645E4 /* ComposerComponentTests.swift in Sources */,

--- a/Strada.xcodeproj/project.pbxproj
+++ b/Strada.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -248,7 +248,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1520;
 				ORGANIZATIONNAME = Basecamp;
 				TargetAttributes = {
 					9274F1E42229963B003E85F4 = {
@@ -356,6 +356,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -391,6 +392,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -421,6 +423,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -456,6 +459,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -539,8 +543,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2WNYUYRS7G;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -549,6 +553,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = dev.hotwire.strada.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -558,8 +563,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2WNYUYRS7G;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -568,6 +573,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = dev.hotwire.strada.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Strada.xcodeproj/xcshareddata/xcschemes/Strada.xcscheme
+++ b/Strada.xcodeproj/xcshareddata/xcschemes/Strada.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1520"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -44,47 +44,47 @@ class BridgeComponentTest: XCTestCase {
     
     // MARK: reply(to:)
     
-    func test_replyToReceivedMessageSucceeds() {
-        let success = component.reply(to: "connect")
-        
+    func test_replyToReceivedMessageSucceeds() async {
+        let success = await component.reply(to: "connect")
+
         XCTAssertTrue(success)
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, message)
     }
     
-    func test_replyToReceivedMessageWithACodableObjectSucceeds() {
+    func test_replyToReceivedMessageWithACodableObjectSucceeds() async {
         let messageData = MessageData(title: "hey", subtitle: "", actionName: "tap")
         let newJsonData = "{\"title\":\"hey\",\"subtitle\":\"\",\"actionName\":\"tap\"}"
         let newMessage = message.replacing(jsonData: newJsonData)
         
-        let success = component.reply(to: "connect", with: messageData)
-        
+        let success = await component.reply(to: "connect", with: messageData)
+
         XCTAssertTrue(success)
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
     }
     
-    func test_replyToMessageNotReceivedWithACodableObjectIgnoresTheReply() {
+    func test_replyToMessageNotReceivedWithACodableObjectIgnoresTheReply() async {
         let messageData = MessageData(title: "hey", subtitle: "", actionName: "tap")
         
-        let success = component.reply(to: "disconnect", with: messageData)
-        
+        let success = await component.reply(to: "disconnect", with: messageData)
+
         XCTAssertFalse(success)
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)
     }
     
-    func test_replyToMessageNotReceivedIgnoresTheReply() {
-        let success = component.reply(to: "disconnect")
-        
+    func test_replyToMessageNotReceivedIgnoresTheReply() async {
+        let success = await component.reply(to: "disconnect")
+
         XCTAssertFalse(success)
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)
     }
     
-    func test_replyToMessageNotReceivedWithJsonDataIgnoresTheReply() {
-        let success = component.reply(to: "disconnect", with: "{\"title\":\"Page-title\"}")
-        
+    func test_replyToMessageNotReceivedWithJsonDataIgnoresTheReply() async {
+        let success = await component.reply(to: "disconnect", with: "{\"title\":\"Page-title\"}")
+
         XCTAssertFalse(success)
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)
@@ -92,12 +92,12 @@ class BridgeComponentTest: XCTestCase {
 
     // MARK: reply(with:)
    
-    func test_replyWithSucceedsWhenBridgeIsSet() {
+    func test_replyWithSucceedsWhenBridgeIsSet() async {
         let newJsonData = "{\"title\":\"Page-title\"}"
         let newMessage = message.replacing(jsonData: newJsonData)
         
-        let success = component.reply(with: newMessage)
-        
+        let success = await component.reply(with: newMessage)
+
         XCTAssertTrue(success)
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, newMessage)

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import WebKit
 import Strada
 
+@MainActor
 class BridgeComponentTest: XCTestCase {
     private var delegate: BridgeDelegateSpy!
     private var destination: AppBridgeDestination!
@@ -223,6 +224,6 @@ class BridgeComponentTest: XCTestCase {
     }
 }
 
-private extension TimeInterval {
+extension TimeInterval {
     static let expectationTimeout: TimeInterval = 5
 }

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -92,6 +92,7 @@ class BridgeComponentTest: XCTestCase {
 
     // MARK: reply(to:) non-async
 
+    @MainActor
     func test_replyToReceivedMessageSucceeds() {
         component.reply(to: "connect")
 
@@ -120,6 +121,7 @@ class BridgeComponentTest: XCTestCase {
 
     // MARK: reply(with:) non-async
 
+    @MainActor
     func test_replyWithSucceedsWhenBridgeIsSet() {
         let newJsonData = "{\"title\":\"Page-title\"}"
         let newMessage = message.replacing(jsonData: newJsonData)

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -223,7 +223,3 @@ class BridgeComponentTest: XCTestCase {
         wait(for: [expectation], timeout: .expectationTimeout)
     }
 }
-
-extension TimeInterval {
-    static let expectationTimeout: TimeInterval = 5
-}

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 import WebKit
-@testable import Strada
+import Strada
 
 class BridgeComponentTest: XCTestCase {
     private var delegate: BridgeDelegateSpy!

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -109,6 +109,82 @@ class BridgeComponentTest: XCTestCase {
 
         wait(for: [expectation], timeout: .expectationTimeout)
     }
+    
+    func test_replyToReceivedMessageWithACodableObjectSucceeds() {
+        let messageData = MessageData(title: "hey", subtitle: "", actionName: "tap")
+        let newJsonData = "{\"title\":\"hey\",\"subtitle\":\"\",\"actionName\":\"tap\"}"
+        let newMessage = message.replacing(jsonData: newJsonData)
+        let expectation = expectation(description: "Wait for completion.")
+
+        component.reply(to: "connect", with: messageData) { [unowned self] result in
+            switch result {
+            case .success(let success):
+                XCTAssertTrue(success)
+                XCTAssertTrue(delegate.replyWithMessageWasCalled)
+                XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
+            case .failure(let error):
+                XCTFail("Failed with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: .expectationTimeout)
+    }
+    
+    func test_replyToMessageNotReceivedWithACodableObjectIgnoresTheReply() {
+        let messageData = MessageData(title: "hey", subtitle: "", actionName: "tap")
+        let expectation = expectation(description: "Wait for completion.")
+
+        component.reply(to: "disconnect", with: messageData) { [unowned self] result in
+            switch result {
+            case .success(let success):
+                XCTAssertFalse(success)
+                XCTAssertFalse(delegate.replyWithMessageWasCalled)
+                XCTAssertNil(delegate.replyWithMessageArg)
+            case .failure(let error):
+                XCTFail("Failed with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: .expectationTimeout)
+    }
+    
+    func test_replyToMessageNotReceivedIgnoresTheReply() {
+        let expectation = expectation(description: "Wait for completion.")
+
+        component.reply(to: "disconnect") { [unowned self] result in
+            switch result {
+            case .success(let success):
+                XCTAssertFalse(success)
+                XCTAssertFalse(delegate.replyWithMessageWasCalled)
+                XCTAssertNil(delegate.replyWithMessageArg)
+            case .failure(let error):
+                XCTFail("Failed with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: .expectationTimeout)
+    }
+    
+    func test_replyToMessageNotReceivedWithJsonDataIgnoresTheReply() {
+        let expectation = expectation(description: "Wait for completion.")
+
+        component.reply(to: "disconnect", with: "{\"title\":\"Page-title\"}") { [unowned self] result in
+            switch result {
+            case .success(let success):
+                XCTAssertFalse(success)
+                XCTAssertFalse(delegate.replyWithMessageWasCalled)
+                XCTAssertNil(delegate.replyWithMessageArg)
+            case .failure(let error):
+                XCTFail("Failed with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: .expectationTimeout)
+    }
 
     // MARK: reply(with:)
    

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -44,46 +44,46 @@ class BridgeComponentTest: XCTestCase {
     
     // MARK: reply(to:)
     
-    func test_replyToReceivedMessageSucceeds() async {
-        let success = await component.reply(to: "connect")
+    func test_replyToReceivedMessageSucceeds() async throws {
+        let success = try await component.reply(to: "connect")
 
         XCTAssertTrue(success)
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, message)
     }
     
-    func test_replyToReceivedMessageWithACodableObjectSucceeds() async {
+    func test_replyToReceivedMessageWithACodableObjectSucceeds() async throws {
         let messageData = MessageData(title: "hey", subtitle: "", actionName: "tap")
         let newJsonData = "{\"title\":\"hey\",\"subtitle\":\"\",\"actionName\":\"tap\"}"
         let newMessage = message.replacing(jsonData: newJsonData)
         
-        let success = await component.reply(to: "connect", with: messageData)
+        let success = try await component.reply(to: "connect", with: messageData)
 
         XCTAssertTrue(success)
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
     }
     
-    func test_replyToMessageNotReceivedWithACodableObjectIgnoresTheReply() async {
+    func test_replyToMessageNotReceivedWithACodableObjectIgnoresTheReply() async throws {
         let messageData = MessageData(title: "hey", subtitle: "", actionName: "tap")
         
-        let success = await component.reply(to: "disconnect", with: messageData)
+        let success = try await component.reply(to: "disconnect", with: messageData)
 
         XCTAssertFalse(success)
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)
     }
     
-    func test_replyToMessageNotReceivedIgnoresTheReply() async {
-        let success = await component.reply(to: "disconnect")
+    func test_replyToMessageNotReceivedIgnoresTheReply() async throws {
+        let success = try await component.reply(to: "disconnect")
 
         XCTAssertFalse(success)
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)
     }
     
-    func test_replyToMessageNotReceivedWithJsonDataIgnoresTheReply() async {
-        let success = await component.reply(to: "disconnect", with: "{\"title\":\"Page-title\"}")
+    func test_replyToMessageNotReceivedWithJsonDataIgnoresTheReply() async throws {
+        let success = try await component.reply(to: "disconnect", with: "{\"title\":\"Page-title\"}")
 
         XCTAssertFalse(success)
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
@@ -92,11 +92,11 @@ class BridgeComponentTest: XCTestCase {
 
     // MARK: reply(with:)
    
-    func test_replyWithSucceedsWhenBridgeIsSet() async {
+    func test_replyWithSucceedsWhenBridgeIsSet() async throws {
         let newJsonData = "{\"title\":\"Page-title\"}"
         let newMessage = message.replacing(jsonData: newJsonData)
         
-        let success = await component.reply(with: newMessage)
+        let success = try await component.reply(with: newMessage)
 
         XCTAssertTrue(success)
         XCTAssertTrue(delegate.replyWithMessageWasCalled)

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -92,18 +92,22 @@ class BridgeComponentTest: XCTestCase {
 
     // MARK: reply(to:) non-async
 
-    @MainActor
     func test_replyToReceivedMessageSucceeds() {
-        component.reply(to: "connect")
+        let expectation = expectation(description: "Wait for completion.")
 
-        wait(for: [expectation(
-            that: \.replyWithMessageWasCalled,
-            on: delegate,
-            willEqual: true
-        )], timeout: .expectationTimeout)
+        component.reply(to: "connect") { [unowned self] result in
+            switch result {
+            case .success(let success):
+                XCTAssert(success)
+                XCTAssertTrue(delegate.replyWithMessageWasCalled)
+                XCTAssertEqual(delegate.replyWithMessageArg, message)
+            case .failure(let error):
+                XCTFail("Failed with error: \(error)")
+            }
+            expectation.fulfill()
+        }
 
-        XCTAssertTrue(delegate.replyWithMessageWasCalled)
-        XCTAssertEqual(delegate.replyWithMessageArg, message)
+        wait(for: [expectation], timeout: .expectationTimeout)
     }
 
     // MARK: reply(with:)
@@ -121,21 +125,25 @@ class BridgeComponentTest: XCTestCase {
 
     // MARK: reply(with:) non-async
 
-    @MainActor
     func test_replyWithSucceedsWhenBridgeIsSet() {
+        let expectation = expectation(description: "Wait for completion.")
+
         let newJsonData = "{\"title\":\"Page-title\"}"
         let newMessage = message.replacing(jsonData: newJsonData)
 
-        component.reply(with: newMessage)
+        component.reply(with: newMessage) { [unowned self] result in
+            switch result {
+            case .success(let success):
+                XCTAssert(success)
+                XCTAssertTrue(delegate.replyWithMessageWasCalled)
+                XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
+            case .failure(let error):
+                XCTFail("Failed with error: \(error)")
+            }
+            expectation.fulfill()
+        }
 
-        wait(for: [expectation(
-            that: \.replyWithMessageWasCalled,
-            on: delegate,
-            willEqual: true
-        )], timeout: .expectationTimeout)
-
-        XCTAssertTrue(delegate.replyWithMessageWasCalled)
-        XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
+        wait(for: [expectation], timeout: .expectationTimeout)
     }
 }
 

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -90,6 +90,21 @@ class BridgeComponentTest: XCTestCase {
         XCTAssertNil(delegate.replyWithMessageArg)
     }
 
+    // MARK: reply(to:) non-async
+
+    func test_replyToReceivedMessageSucceeds() {
+        component.reply(to: "connect")
+
+        wait(for: [expectation(
+            that: \.replyWithMessageWasCalled,
+            on: delegate,
+            willEqual: true
+        )], timeout: 1)
+
+        XCTAssertTrue(delegate.replyWithMessageWasCalled)
+        XCTAssertEqual(delegate.replyWithMessageArg, message)
+    }
+
     // MARK: reply(with:)
    
     func test_replyWithSucceedsWhenBridgeIsSet() async throws {
@@ -99,6 +114,24 @@ class BridgeComponentTest: XCTestCase {
         let success = try await component.reply(with: newMessage)
 
         XCTAssertTrue(success)
+        XCTAssertTrue(delegate.replyWithMessageWasCalled)
+        XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
+    }
+
+    // MARK: reply(with:) non-async
+
+    func test_replyWithSucceedsWhenBridgeIsSet() {
+        let newJsonData = "{\"title\":\"Page-title\"}"
+        let newMessage = message.replacing(jsonData: newJsonData)
+
+        component.reply(with: newMessage)
+
+        wait(for: [expectation(
+            that: \.replyWithMessageWasCalled,
+            on: delegate,
+            willEqual: true
+        )], timeout: 1)
+
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
     }

--- a/Tests/BridgeDelegateTests.swift
+++ b/Tests/BridgeDelegateTests.swift
@@ -22,8 +22,8 @@ class BridgeDelegateTests: XCTestCase {
         delegate.onViewDidLoad()
     }
     
-    func testBridgeDidInitialize() async {
-        await delegate.bridgeDidInitialize()
+    func testBridgeDidInitialize() async throws {
+        try await delegate.bridgeDidInitialize()
 
         XCTAssertTrue(bridge.registerComponentsWasCalled)
         XCTAssertEqual(bridge.registerComponentsArg, ["one", "two"])
@@ -143,20 +143,20 @@ class BridgeDelegateTests: XCTestCase {
     
     // MARK: reply(with:)
    
-    func test_replyWithSucceedsWhenBridgeIsSet() async {
+    func test_replyWithSucceedsWhenBridgeIsSet() async throws {
         let message = testMessage()
-        let success = await delegate.reply(with: message)
+        let success = try await delegate.reply(with: message)
 
         XCTAssertTrue(success)
         XCTAssertTrue(bridge.replyWithMessageWasCalled)
         XCTAssertEqual(bridge.replyWithMessageArg, message)
     }
     
-    func test_replyWithFailsWhenBridgeNotSet() async {
+    func test_replyWithFailsWhenBridgeNotSet() async throws {
         delegate.bridge = nil
 
         let message = testMessage()
-        let success = await delegate.reply(with: message)
+        let success = try await delegate.reply(with: message)
 
         XCTAssertFalse(success)
         XCTAssertFalse(bridge.replyWithMessageWasCalled)

--- a/Tests/BridgeDelegateTests.swift
+++ b/Tests/BridgeDelegateTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import WebKit
 @testable import Strada
 
+@MainActor
 class BridgeDelegateTests: XCTestCase {
     private var delegate: BridgeDelegate!
     private var destination: AppBridgeDestination!

--- a/Tests/BridgeDelegateTests.swift
+++ b/Tests/BridgeDelegateTests.swift
@@ -22,9 +22,9 @@ class BridgeDelegateTests: XCTestCase {
         delegate.onViewDidLoad()
     }
     
-    func testBridgeDidInitialize() {
-        delegate.bridgeDidInitialize()
-        
+    func testBridgeDidInitialize() async {
+        await delegate.bridgeDidInitialize()
+
         XCTAssertTrue(bridge.registerComponentsWasCalled)
         XCTAssertEqual(bridge.registerComponentsArg, ["one", "two"])
      
@@ -143,20 +143,20 @@ class BridgeDelegateTests: XCTestCase {
     
     // MARK: reply(with:)
    
-    func test_replyWithSucceedsWhenBridgeIsSet() {
+    func test_replyWithSucceedsWhenBridgeIsSet() async {
         let message = testMessage()
-        let success = delegate.reply(with: message)
-        
+        let success = await delegate.reply(with: message)
+
         XCTAssertTrue(success)
         XCTAssertTrue(bridge.replyWithMessageWasCalled)
         XCTAssertEqual(bridge.replyWithMessageArg, message)
     }
     
-    func test_replyWithFailsWhenBridgeNotSet() {
+    func test_replyWithFailsWhenBridgeNotSet() async {
         delegate.bridge = nil
 
         let message = testMessage()
-        let success = delegate.reply(with: message)
+        let success = await delegate.reply(with: message)
 
         XCTAssertFalse(success)
         XCTAssertFalse(bridge.replyWithMessageWasCalled)

--- a/Tests/BridgeDelegateTests.swift
+++ b/Tests/BridgeDelegateTests.swift
@@ -24,8 +24,11 @@ class BridgeDelegateTests: XCTestCase {
     }
     
     func testBridgeDidInitialize() async throws {
-        try await delegate.bridgeDidInitialize()
-
+        await withCheckedContinuation { continuation in
+            bridge.registerComponentsContinuation = continuation
+            delegate.bridgeDidInitialize()
+        }
+        
         XCTAssertTrue(bridge.registerComponentsWasCalled)
         XCTAssertEqual(bridge.registerComponentsArg, ["one", "two"])
      

--- a/Tests/BridgeTests.swift
+++ b/Tests/BridgeTests.swift
@@ -4,60 +4,25 @@ import WebKit
 
 @MainActor
 class BridgeTests: XCTestCase {
-    func testInitWithANewWebViewAutomaticallyLoadsIntoWebView() async {
-        let webView = WKWebView()
-        let userContentController = webView.configuration.userContentController
-        XCTAssertTrue(userContentController.userScripts.isEmpty)
-        
-        await Bridge.initialize(webView)
-        XCTAssertEqual(userContentController.userScripts.count, 1)
-    }
-    
-    func testInitWithTheSameWebViewDoesNotLoadTwice() async {
-        let webView = WKWebView()
-        let userContentController = webView.configuration.userContentController
-        XCTAssertTrue(userContentController.userScripts.isEmpty)
-        
-        await Bridge.initialize(webView)
-        XCTAssertEqual(userContentController.userScripts.count, 1)
-        
-        await Bridge.initialize(webView)
-        XCTAssertEqual(userContentController.userScripts.count, 1)
-    }
-    
     func testInitWithANewWebViewAutomaticallyLoadsIntoWebView() {
         let webView = WKWebView()
         let userContentController = webView.configuration.userContentController
         XCTAssertTrue(userContentController.userScripts.isEmpty)
-
-        let expectation = expectation(description: "Wait for completion.")
-        Bridge.initialize(webView) {
-            XCTAssertEqual(userContentController.userScripts.count, 1)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: .expectationTimeout)
+        
+        Bridge.initialize(webView)
+        XCTAssertEqual(userContentController.userScripts.count, 1)
     }
     
     func testInitWithTheSameWebViewDoesNotLoadTwice() {
         let webView = WKWebView()
         let userContentController = webView.configuration.userContentController
         XCTAssertTrue(userContentController.userScripts.isEmpty)
-
-        let expectation1 = expectation(description: "Wait for completion.")
-        Bridge.initialize(webView) {
-            XCTAssertEqual(userContentController.userScripts.count, 1)
-            expectation1.fulfill()
-        }
         
-        let expectation2 = expectation(description: "Wait for completion.")
+        Bridge.initialize(webView)
+        XCTAssertEqual(userContentController.userScripts.count, 1)
         
-        Bridge.initialize(webView) {
-            XCTAssertEqual(userContentController.userScripts.count, 1)
-            expectation2.fulfill()
-        }
-
-        wait(for: [expectation1, expectation2], timeout: .expectationTimeout)
+        Bridge.initialize(webView)
+        XCTAssertEqual(userContentController.userScripts.count, 1)
     }
 
     /// NOTE: Each call to `webView.evaluateJavaScript(String)` will throw an error.

--- a/Tests/BridgeTests.swift
+++ b/Tests/BridgeTests.swift
@@ -24,34 +24,38 @@ class BridgeTests: XCTestCase {
         XCTAssertEqual(userContentController.userScripts.count, 1)
     }
     
-    func testRegisterComponentCallsJavaScriptFunction() {
+    @MainActor
+    func testRegisterComponentCallsJavaScriptFunction() async {
         let webView = TestWebView()
         let bridge = Bridge(webView: webView)
         XCTAssertNil(webView.lastEvaluatedJavaScript)
         
-        bridge.register(component: "test")
+        await bridge.register(component: "test")
         XCTAssertEqual(webView.lastEvaluatedJavaScript, "window.nativeBridge.register(\"test\")")
     }
     
-    func testRegisterComponentsCallsJavaScriptFunction() {
+    @MainActor
+    func testRegisterComponentsCallsJavaScriptFunction() async {
         let webView = TestWebView()
         let bridge = Bridge(webView: webView)
         XCTAssertNil(webView.lastEvaluatedJavaScript)
         
-        bridge.register(components: ["one", "two"])
+        await bridge.register(components: ["one", "two"])
         XCTAssertEqual(webView.lastEvaluatedJavaScript, "window.nativeBridge.register([\"one\",\"two\"])")
     }
     
-    func testUnregisterComponentCallsJavaScriptFunction() {
+    @MainActor
+    func testUnregisterComponentCallsJavaScriptFunction() async {
         let webView = TestWebView()
         let bridge = Bridge(webView: webView)
         XCTAssertNil(webView.lastEvaluatedJavaScript)
         
-        bridge.unregister(component: "test")
+        await bridge.unregister(component: "test")
         XCTAssertEqual(webView.lastEvaluatedJavaScript, "window.nativeBridge.unregister(\"test\")")
     }
     
-    func testSendCallsJavaScriptFunction() {
+    @MainActor
+    func testSendCallsJavaScriptFunction() async {
         let webView = TestWebView()
         let bridge = Bridge(webView: webView)
         XCTAssertNil(webView.lastEvaluatedJavaScript)
@@ -67,52 +71,37 @@ class BridgeTests: XCTestCase {
                               jsonData: data)
 
         
-        bridge.reply(with: message)
+        await bridge.reply(with: message)
         XCTAssertEqual(webView.lastEvaluatedJavaScript, "window.nativeBridge.replyWith({\"component\":\"page\",\"event\":\"connect\",\"data\":{\"title\":\"Page-title\"},\"id\":\"1\"})")
     }
     
-    func testEvaluateJavaScript() {
+    @MainActor
+    func testEvaluateJavaScript() async {
         let webView = TestWebView()
         let bridge = Bridge(webView: webView)
         XCTAssertNil(webView.lastEvaluatedJavaScript)
         
-        bridge.evaluate(javaScript: "test(1,2,3)")
+        await bridge.evaluate(javaScript: "test(1,2,3)")
         XCTAssertEqual(webView.lastEvaluatedJavaScript, "test(1,2,3)")
     }
     
-    func testEvaluateJavaScriptReturnsErrorForNoWebView() {
+    @MainActor
+    func testEvaluateJavaScriptReturnsErrorForNoWebView() async {
         let bridge = Bridge(webView: WKWebView())
         bridge.webView = nil
-        let expectation = self.expectation(description: "error handler")
         
-        bridge.evaluate(function: "test", arguments: []) { (result, error) in
-            XCTAssertEqual(error! as! BridgeError, BridgeError.missingWebView)
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 2)
+        let result = await bridge.evaluate(function: "test", arguments: [])
+        XCTAssertEqual(result.error! as! BridgeError, BridgeError.missingWebView)
     }
     
-    func testEvaluateFunction() {
+    @MainActor
+    func testEvaluateFunction() async {
         let webView = TestWebView()
         let bridge = Bridge(webView: webView)
         XCTAssertNil(webView.lastEvaluatedJavaScript)
         
-        bridge.evaluate(function: "test", arguments: [1, 2, 3])
+        await _ = bridge.evaluate(function: "test", arguments: [1, 2, 3])
         XCTAssertEqual(webView.lastEvaluatedJavaScript, "test(1,2,3)")
-    }
-    
-    func testEvaluateFunctionCallsCompletionHandler() {
-        let webView = TestWebView()
-        let bridge = Bridge(webView: webView)
-        
-        let expectation = self.expectation(description: "completion handler")
-        
-        bridge.evaluate(function: "test", arguments: []) { (result, error) in
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 2)
     }
 }
 

--- a/Tests/ComponentTestExample/ComposerComponent.swift
+++ b/Tests/ComponentTestExample/ComposerComponent.swift
@@ -17,7 +17,7 @@ final class ComposerComponent: BridgeComponent {
         }
     }
     
-    func selectSender(emailAddress: String) async {
+    func selectSender(emailAddress: String) async throws {
         guard let message = receivedMessage(for: InboundEvent.connect.rawValue),
               let senders: [Sender] = message.data() else {
             return
@@ -29,7 +29,7 @@ final class ComposerComponent: BridgeComponent {
         
         let newMessage = message.replacing(event: OutboundEvent.selectSender.rawValue,
                                            data: SelectSenderMessageData(selectedIndex: sender.index))
-        await reply(with: newMessage)
+        try await reply(with: newMessage)
     }
     
     func selectedSender() -> String? {

--- a/Tests/ComponentTestExample/ComposerComponent.swift
+++ b/Tests/ComponentTestExample/ComposerComponent.swift
@@ -17,7 +17,7 @@ final class ComposerComponent: BridgeComponent {
         }
     }
     
-    func selectSender(emailAddress: String) {
+    func selectSender(emailAddress: String) async {
         guard let message = receivedMessage(for: InboundEvent.connect.rawValue),
               let senders: [Sender] = message.data() else {
             return
@@ -29,7 +29,7 @@ final class ComposerComponent: BridgeComponent {
         
         let newMessage = message.replacing(event: OutboundEvent.selectSender.rawValue,
                                            data: SelectSenderMessageData(selectedIndex: sender.index))
-        reply(with: newMessage)
+        await reply(with: newMessage)
     }
     
     func selectedSender() -> String? {

--- a/Tests/ComponentTestExample/ComposerComponent.swift
+++ b/Tests/ComponentTestExample/ComposerComponent.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import Strada
+import Strada
 
 final class ComposerComponent: BridgeComponent {
     static override var name: String { "composer" }

--- a/Tests/ComponentTestExample/ComposerComponentTests.swift
+++ b/Tests/ComponentTestExample/ComposerComponentTests.swift
@@ -47,10 +47,10 @@ final class ComposerComponentTests: XCTestCase {
     
     // MARK: Select sender tests
     
-    func test_selectSender_emailFound_sendsTheCorrectMessageReply() async {
+    func test_selectSender_emailFound_sendsTheCorrectMessageReply() async throws {
         component.didReceive(message: connectMessage)
         
-        await component.selectSender(emailAddress: "user1@37signals.com")
+        try await component.selectSender(emailAddress: "user1@37signals.com")
 
         let expectedMessage = connectMessage.replacing(event: "select-sender",
                                                        jsonData: "{\"selectedIndex\":1}")
@@ -58,17 +58,17 @@ final class ComposerComponentTests: XCTestCase {
         XCTAssertEqual(delegate.replyWithMessageArg, expectedMessage)
     }
     
-    func test_selectSender_emailNotFound_doesNotSendAnyMessage() async {
+    func test_selectSender_emailNotFound_doesNotSendAnyMessage() async throws {
         component.didReceive(message: connectMessage)
         
-        await component.selectSender(emailAddress: "test@37signals.com")
+        try await component.selectSender(emailAddress: "test@37signals.com")
 
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)
     }
     
-    func test_selectSender_beforeConnectMessage_doesNotSendAnyMessage() async {
-        await component.selectSender(emailAddress: "user1@37signals.com")
+    func test_selectSender_beforeConnectMessage_doesNotSendAnyMessage() async throws {
+        try await component.selectSender(emailAddress: "user1@37signals.com")
 
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)

--- a/Tests/ComponentTestExample/ComposerComponentTests.swift
+++ b/Tests/ComponentTestExample/ComposerComponentTests.swift
@@ -47,29 +47,29 @@ final class ComposerComponentTests: XCTestCase {
     
     // MARK: Select sender tests
     
-    func test_selectSender_emailFound_sendsTheCorrectMessageReply() {
+    func test_selectSender_emailFound_sendsTheCorrectMessageReply() async {
         component.didReceive(message: connectMessage)
         
-        component.selectSender(emailAddress: "user1@37signals.com")
-        
+        await component.selectSender(emailAddress: "user1@37signals.com")
+
         let expectedMessage = connectMessage.replacing(event: "select-sender",
                                                        jsonData: "{\"selectedIndex\":1}")
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, expectedMessage)
     }
     
-    func test_selectSender_emailNotFound_doesNotSendAnyMessage() {
+    func test_selectSender_emailNotFound_doesNotSendAnyMessage() async {
         component.didReceive(message: connectMessage)
         
-        component.selectSender(emailAddress: "test@37signals.com")
-        
+        await component.selectSender(emailAddress: "test@37signals.com")
+
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)
     }
     
-    func test_selectSender_beforeConnectMessage_doesNotSendAnyMessage() {
-        component.selectSender(emailAddress: "user1@37signals.com")
-        
+    func test_selectSender_beforeConnectMessage_doesNotSendAnyMessage() async {
+        await component.selectSender(emailAddress: "user1@37signals.com")
+
         XCTAssertFalse(delegate.replyWithMessageWasCalled)
         XCTAssertNil(delegate.replyWithMessageArg)
     }

--- a/Tests/ComponentTestExample/ComposerComponentTests.swift
+++ b/Tests/ComponentTestExample/ComposerComponentTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import WebKit
-@testable import Strada
+import Strada
 
 final class ComposerComponentTests: XCTestCase {
     private var delegate: BridgeDelegateSpy!

--- a/Tests/ComponentTestExample/ComposerComponentTests.swift
+++ b/Tests/ComponentTestExample/ComposerComponentTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import WebKit
 import Strada
 
+@MainActor
 final class ComposerComponentTests: XCTestCase {
     private var delegate: BridgeDelegateSpy!
     private var destination: AppBridgeDestination!

--- a/Tests/Extensions/TimeInterval+ExpectationTimeout.swift
+++ b/Tests/Extensions/TimeInterval+ExpectationTimeout.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension TimeInterval {
+    static let expectationTimeout: TimeInterval = 5
+}

--- a/Tests/MessageTests.swift
+++ b/Tests/MessageTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Strada
+import Strada
 
 class MessageTests: XCTestCase {
     

--- a/Tests/Spies/BridgeComponentSpy.swift
+++ b/Tests/Spies/BridgeComponentSpy.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import Strada
+import Strada
 
 final class BridgeComponentSpy: BridgeComponent {
     static override var name: String { "two" }

--- a/Tests/Spies/BridgeDelegateSpy.swift
+++ b/Tests/Spies/BridgeDelegateSpy.swift
@@ -2,12 +2,12 @@ import Foundation
 import WebKit
 import Strada
 
-final class BridgeDelegateSpy: NSObject, BridgingDelegate {
+final class BridgeDelegateSpy: BridgingDelegate {
     let location: String = ""
     let destination: BridgeDestination = AppBridgeDestination()
     var webView: WKWebView? = nil
     
-    @objc dynamic var replyWithMessageWasCalled = false
+    var replyWithMessageWasCalled = false
     var replyWithMessageArg: Message?
     
     func webViewDidBecomeActive(_ webView: WKWebView) {

--- a/Tests/Spies/BridgeDelegateSpy.swift
+++ b/Tests/Spies/BridgeDelegateSpy.swift
@@ -1,6 +1,6 @@
 import Foundation
 import WebKit
-@testable import Strada
+import Strada
 
 final class BridgeDelegateSpy: BridgingDelegate {
     let location: String = ""

--- a/Tests/Spies/BridgeDelegateSpy.swift
+++ b/Tests/Spies/BridgeDelegateSpy.swift
@@ -7,7 +7,7 @@ final class BridgeDelegateSpy: NSObject, BridgingDelegate {
     let destination: BridgeDestination = AppBridgeDestination()
     var webView: WKWebView? = nil
     
-    var replyWithMessageWasCalled = false
+    @objc dynamic var replyWithMessageWasCalled = false
     var replyWithMessageArg: Message?
     
     func webViewDidBecomeActive(_ webView: WKWebView) {

--- a/Tests/Spies/BridgeDelegateSpy.swift
+++ b/Tests/Spies/BridgeDelegateSpy.swift
@@ -2,7 +2,7 @@ import Foundation
 import WebKit
 import Strada
 
-final class BridgeDelegateSpy: BridgingDelegate {
+final class BridgeDelegateSpy: NSObject, BridgingDelegate {
     let location: String = ""
     let destination: BridgeDestination = AppBridgeDestination()
     var webView: WKWebView? = nil

--- a/Tests/Spies/BridgeDelegateSpy.swift
+++ b/Tests/Spies/BridgeDelegateSpy.swift
@@ -49,7 +49,7 @@ final class BridgeDelegateSpy: BridgingDelegate {
         return nil
     }
     
-    func bridgeDidInitialize() async throws {
+    func bridgeDidInitialize() {
         
     }
     

--- a/Tests/Spies/BridgeSpy.swift
+++ b/Tests/Spies/BridgeSpy.swift
@@ -9,7 +9,15 @@ final class BridgeSpy: Bridgable {
     var registerComponentWasCalled = false
     var registerComponentArg: String? = nil
     
-    var registerComponentsWasCalled = false
+    var registerComponentsWasCalled = false {
+        didSet {
+            if registerComponentsWasCalled {
+                registerComponentsContinuation?.resume()
+                registerComponentsContinuation = nil
+            }
+        }
+    }
+    var registerComponentsContinuation: CheckedContinuation<Void, Never>?
     var registerComponentsArg: [String]? = nil
     
     var unregisterComponentWasCalled = false

--- a/Tests/UserAgentTests.swift
+++ b/Tests/UserAgentTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import Strada
+import Strada
 
 class UserAgentTests: XCTestCase {
     func testUserAgentSubstringWithTwoComponents() {


### PR DESCRIPTION
A second take on #26 where the two public functions `reply(to:)` and `reply(with:)` are wrapped in a `Task {}` block. This lets a developer use the async version or non-async version depending on their preference. For example:

```swift
// From an async, throwing function:
func doSomething() async throws {
    reply(to: "connect") // Calls async, throwing version.
}

// From a non-async, non-throwing function:
func doSomethingNow() {
    reply(to: "connect") // Calls non-async version.
}

// From a non-async, non-throwing function (again):
func doSomethingLater() {
    Task { try await reply(to: "connect") } // Calls async, throwing version.
}
```

### Notes
* The tests are currently failing. I think we had some tests that threw errors before that are now being exposed but I haven't dug in, yet.
* The actual change to the public API is in the most recent commit, [2a9aa0](2a9aa02283968ce7fc8871f43ade768bb10dd291). 