### PR TITLE
Async javascript take 2 feedback

### DIFF
--- a/Source/Bridge.swift
+++ b/Source/Bridge.swift
@@ -18,8 +18,6 @@ protocol Bridgable: AnyObject {
 /// `Bridge` is the object for configuring a web view and
 /// the channel for sending/receiving messages
 public final class Bridge: Bridgable {
-    typealias CompletionHandler = (_ result: Any?, _ error: Error?) -> Void
-
     weak var delegate: BridgeDelegate?
     weak var webView: WKWebView?
 

--- a/Source/Bridge.swift
+++ b/Source/Bridge.swift
@@ -76,8 +76,8 @@ public final class Bridge: Bridgable {
 //    }
     @MainActor
     @discardableResult
-    func evaluate(javaScript: String) async throws -> Any? {
-        guard let webView = webView else {
+    func evaluate(javaScript: String) async throws -> Any {
+        guard let webView else {
             throw BridgeError.missingWebView
         }
 
@@ -92,7 +92,7 @@ public final class Bridge: Bridgable {
     /// Evaluates a JavaScript function with optional arguments by encoding the arguments
     /// Function should not include the parens
     /// Usage: evaluate(function: "console.log", arguments: ["test"])
-    func evaluate(function: String, arguments: [Any] = []) async throws -> Any? {
+    func evaluate(function: String, arguments: [Any] = []) async throws -> Any {
         try await evaluate(javaScript: JavaScript(functionName: function, arguments: arguments).toString())
     }
 
@@ -153,7 +153,7 @@ public final class Bridge: Bridgable {
     // MARK: - JavaScript Evaluation
 
     @discardableResult
-    private func evaluate(javaScript: JavaScript) async throws -> Any? {
+    private func evaluate(javaScript: JavaScript) async throws -> Any {
         do {
             return try await evaluate(javaScript: javaScript.toString())
         } catch {

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -99,7 +99,7 @@ class BridgeComponentTest: XCTestCase {
             that: \.replyWithMessageWasCalled,
             on: delegate,
             willEqual: true
-        )], timeout: 1)
+        )], timeout: .expectationTimeout)
 
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, message)
@@ -130,9 +130,13 @@ class BridgeComponentTest: XCTestCase {
             that: \.replyWithMessageWasCalled,
             on: delegate,
             willEqual: true
-        )], timeout: 1)
+        )], timeout: .expectationTimeout)
 
         XCTAssertTrue(delegate.replyWithMessageWasCalled)
         XCTAssertEqual(delegate.replyWithMessageArg, newMessage)
     }
+}
+
+private extension TimeInterval {
+    static let expectationTimeout: TimeInterval = 5
 }

--- a/Tests/Spies/BridgeDelegateSpy.swift
+++ b/Tests/Spies/BridgeDelegateSpy.swift
@@ -18,7 +18,7 @@ final class BridgeDelegateSpy: NSObject, BridgingDelegate {
         
     }
     
-    func reply(with message: Message) -> Bool {
+    func reply(with message: Message) async throws -> Bool {
         replyWithMessageWasCalled = true
         replyWithMessageArg = message
         
@@ -49,7 +49,7 @@ final class BridgeDelegateSpy: NSObject, BridgingDelegate {
         return nil
     }
     
-    func bridgeDidInitialize() {
+    func bridgeDidInitialize() async throws {
         
     }
     


### PR DESCRIPTION
This PR:
- fixes failing `BridgeTests`.
- returns non optional Any from `evaluate(javaScript: String)`