### PR TITLE
Ensure thread safety

### DIFF
--- a/Source/BridgeComponent.swift
+++ b/Source/BridgeComponent.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@MainActor
 protocol BridgingComponent: AnyObject {
     static var name: String { get }
     var delegate: BridgingDelegate { get }
@@ -22,6 +23,7 @@ protocol BridgingComponent: AnyObject {
     func viewDidDisappear()
 }
 
+@MainActor
 open class BridgeComponent: BridgingComponent {
     public typealias ReplyCompletionHandler = (Result<Bool, Error>) -> Void
 
@@ -30,7 +32,7 @@ open class BridgeComponent: BridgingComponent {
     /// Subclasses must provide their own implementation of this property.
     ///
     /// - Note: This property is used for identifying the component.
-    open class var name: String {
+    nonisolated open class var name: String {
         fatalError("BridgeComponent subclass must provide a unique 'name'")
     }
     
@@ -149,7 +151,7 @@ open class BridgeComponent: BridgingComponent {
     
     @discardableResult
     /// Replies to the web with the last received message for a given `event`, replacing its `jsonData`
-    /// with the provided `Encodable` object. 
+    /// with the provided `Encodable` object.
     ///
     /// NOTE: If a message has not been received for the given `event`, the reply will be ignored.
     ///
@@ -275,3 +277,4 @@ open class BridgeComponent: BridgingComponent {
     
     private var receivedMessages = [String: Message]()
 }
+

--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -21,7 +21,7 @@ public protocol BridgingDelegate: AnyObject {
     
     func component<C: BridgeComponent>() -> C?
     
-    func bridgeDidInitialize() async throws
+    func bridgeDidInitialize()
     func bridgeDidReceiveMessage(_ message: Message) -> Bool
 }
 
@@ -111,9 +111,15 @@ public final class BridgeDelegate: BridgingDelegate {
     
     // MARK: Internal use
     
-    public func bridgeDidInitialize() async throws {
+    public func bridgeDidInitialize() {
         let componentNames = componentTypes.map { $0.name }
-        try await bridge?.register(components: componentNames)
+        Task {
+            do {
+                try await bridge?.register(components: componentNames)
+            } catch {
+                logger.error("bridgeDidFailToRegisterComponents: \(error)")
+            }
+        }
     }
     
     @discardableResult

--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -3,6 +3,7 @@ import WebKit
 
 public protocol BridgeDestination: AnyObject {}
 
+@MainActor
 public protocol BridgingDelegate: AnyObject {
     var location: String { get }
     var destination: BridgeDestination { get }
@@ -24,6 +25,7 @@ public protocol BridgingDelegate: AnyObject {
     func bridgeDidReceiveMessage(_ message: Message) -> Bool
 }
 
+@MainActor
 public final class BridgeDelegate: BridgingDelegate {
     public let location: String
     public unowned let destination: BridgeDestination
@@ -153,4 +155,3 @@ public final class BridgeDelegate: BridgingDelegate {
         return component
     }
 }
-

--- a/Source/ScriptMessageHandler.swift
+++ b/Source/ScriptMessageHandler.swift
@@ -1,7 +1,7 @@
 import WebKit
 
 protocol ScriptMessageHandlerDelegate: AnyObject {
-    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage) async throws
+    func scriptMessageHandlerDidReceiveMessage(_ scriptMessage: WKScriptMessage)
 }
 
 // Avoids retain cycle caused by WKUserContentController
@@ -13,6 +13,6 @@ final class ScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
     
     func userContentController(_ userContentController: WKUserContentController, didReceive scriptMessage: WKScriptMessage) {
-        Task { try await delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage) }
+        delegate?.scriptMessageHandlerDidReceiveMessage(scriptMessage)
     }
 }

--- a/Strada.xcodeproj/project.pbxproj
+++ b/Strada.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		E2DB15912A7163B0001EE08C /* BridgeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DB15902A7163B0001EE08C /* BridgeDelegate.swift */; };
 		E2DB15932A7282CF001EE08C /* BridgeComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DB15922A7282CF001EE08C /* BridgeComponent.swift */; };
 		E2DB15952A72B0A8001EE08C /* BridgeDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DB15942A72B0A8001EE08C /* BridgeDelegateTests.swift */; };
+		E2F4E06B2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F4E06A2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift */; };
 		E2FDCF982A8297DA003D27AE /* BridgeComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FDCF972A8297DA003D27AE /* BridgeComponentTests.swift */; };
 		E2FDCF9B2A829AEE003D27AE /* BridgeSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FDCF9A2A829AEE003D27AE /* BridgeSpy.swift */; };
 		E2FDCF9D2A829C6F003D27AE /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FDCF9C2A829C6F003D27AE /* TestData.swift */; };
@@ -79,6 +80,7 @@
 		E2DB15902A7163B0001EE08C /* BridgeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeDelegate.swift; sourceTree = "<group>"; };
 		E2DB15922A7282CF001EE08C /* BridgeComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeComponent.swift; sourceTree = "<group>"; };
 		E2DB15942A72B0A8001EE08C /* BridgeDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeDelegateTests.swift; sourceTree = "<group>"; };
+		E2F4E06A2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ExpectationTimeout.swift"; sourceTree = "<group>"; };
 		E2FDCF972A8297DA003D27AE /* BridgeComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeComponentTests.swift; sourceTree = "<group>"; };
 		E2FDCF9A2A829AEE003D27AE /* BridgeSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeSpy.swift; sourceTree = "<group>"; };
 		E2FDCF9C2A829C6F003D27AE /* TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
@@ -146,6 +148,7 @@
 		9274F1F22229963B003E85F4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E2F4E0692B9095A5000A3A24 /* Extensions */,
 				E227FAF12A94D48C00A645E4 /* ComponentTestExample */,
 				E2FDCF9C2A829C6F003D27AE /* TestData.swift */,
 				E2FDCF992A829AD5003D27AE /* Spies */,
@@ -179,6 +182,14 @@
 				E227FAF22A94D57300A645E4 /* ComposerComponentTests.swift */,
 			);
 			path = ComponentTestExample;
+			sourceTree = "<group>";
+		};
+		E2F4E0692B9095A5000A3A24 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E2F4E06A2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		E2FDCF992A829AD5003D27AE /* Spies */ = {
@@ -327,6 +338,7 @@
 			files = (
 				E2DB15952A72B0A8001EE08C /* BridgeDelegateTests.swift in Sources */,
 				E227FAF02A94D34E00A645E4 /* ComposerComponent.swift in Sources */,
+				E2F4E06B2B9095BC000A3A24 /* TimeInterval+ExpectationTimeout.swift in Sources */,
 				E227FAEE2A94B35900A645E4 /* BridgeDelegateSpy.swift in Sources */,
 				C11349C2258801F6000A6E56 /* JavaScriptTests.swift in Sources */,
 				E227FAF32A94D57300A645E4 /* ComposerComponentTests.swift in Sources */,

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import WebKit
 import Strada
 
+@MainActor
 class BridgeComponentTest: XCTestCase {
     private var delegate: BridgeDelegateSpy!
     private var destination: AppBridgeDestination!
@@ -223,6 +224,6 @@ class BridgeComponentTest: XCTestCase {
     }
 }
 
-private extension TimeInterval {
+extension TimeInterval {
     static let expectationTimeout: TimeInterval = 5
 }

--- a/Tests/BridgeComponentTests.swift
+++ b/Tests/BridgeComponentTests.swift
@@ -223,7 +223,3 @@ class BridgeComponentTest: XCTestCase {
         wait(for: [expectation], timeout: .expectationTimeout)
     }
 }
-
-extension TimeInterval {
-    static let expectationTimeout: TimeInterval = 5
-}

--- a/Tests/BridgeDelegateTests.swift
+++ b/Tests/BridgeDelegateTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import WebKit
 @testable import Strada
 
+@MainActor
 class BridgeDelegateTests: XCTestCase {
     private var delegate: BridgeDelegate!
     private var destination: AppBridgeDestination!

--- a/Tests/BridgeDelegateTests.swift
+++ b/Tests/BridgeDelegateTests.swift
@@ -24,8 +24,11 @@ class BridgeDelegateTests: XCTestCase {
     }
     
     func testBridgeDidInitialize() async throws {
-        try await delegate.bridgeDidInitialize()
-
+        await withCheckedContinuation { continuation in
+            bridge.registerComponentsContinuation = continuation
+            delegate.bridgeDidInitialize()
+        }
+        
         XCTAssertTrue(bridge.registerComponentsWasCalled)
         XCTAssertEqual(bridge.registerComponentsArg, ["one", "two"])
      

--- a/Tests/BridgeTests.swift
+++ b/Tests/BridgeTests.swift
@@ -4,60 +4,25 @@ import WebKit
 
 @MainActor
 class BridgeTests: XCTestCase {
-    func testInitWithANewWebViewAutomaticallyLoadsIntoWebView() async {
-        let webView = WKWebView()
-        let userContentController = webView.configuration.userContentController
-        XCTAssertTrue(userContentController.userScripts.isEmpty)
-        
-        await Bridge.initialize(webView)
-        XCTAssertEqual(userContentController.userScripts.count, 1)
-    }
-    
-    func testInitWithTheSameWebViewDoesNotLoadTwice() async {
-        let webView = WKWebView()
-        let userContentController = webView.configuration.userContentController
-        XCTAssertTrue(userContentController.userScripts.isEmpty)
-        
-        await Bridge.initialize(webView)
-        XCTAssertEqual(userContentController.userScripts.count, 1)
-        
-        await Bridge.initialize(webView)
-        XCTAssertEqual(userContentController.userScripts.count, 1)
-    }
-    
     func testInitWithANewWebViewAutomaticallyLoadsIntoWebView() {
         let webView = WKWebView()
         let userContentController = webView.configuration.userContentController
         XCTAssertTrue(userContentController.userScripts.isEmpty)
-
-        let expectation = expectation(description: "Wait for completion.")
-        Bridge.initialize(webView) {
-            XCTAssertEqual(userContentController.userScripts.count, 1)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: .expectationTimeout)
+        
+        Bridge.initialize(webView)
+        XCTAssertEqual(userContentController.userScripts.count, 1)
     }
     
     func testInitWithTheSameWebViewDoesNotLoadTwice() {
         let webView = WKWebView()
         let userContentController = webView.configuration.userContentController
         XCTAssertTrue(userContentController.userScripts.isEmpty)
-
-        let expectation1 = expectation(description: "Wait for completion.")
-        Bridge.initialize(webView) {
-            XCTAssertEqual(userContentController.userScripts.count, 1)
-            expectation1.fulfill()
-        }
         
-        let expectation2 = expectation(description: "Wait for completion.")
+        Bridge.initialize(webView)
+        XCTAssertEqual(userContentController.userScripts.count, 1)
         
-        Bridge.initialize(webView) {
-            XCTAssertEqual(userContentController.userScripts.count, 1)
-            expectation2.fulfill()
-        }
-
-        wait(for: [expectation1, expectation2], timeout: .expectationTimeout)
+        Bridge.initialize(webView)
+        XCTAssertEqual(userContentController.userScripts.count, 1)
     }
 
     /// NOTE: Each call to `webView.evaluateJavaScript(String)` will throw an error.

--- a/Tests/ComponentTestExample/ComposerComponentTests.swift
+++ b/Tests/ComponentTestExample/ComposerComponentTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import WebKit
 import Strada
 
+@MainActor
 final class ComposerComponentTests: XCTestCase {
     private var delegate: BridgeDelegateSpy!
     private var destination: AppBridgeDestination!

--- a/Tests/Extensions/TimeInterval+ExpectationTimeout.swift
+++ b/Tests/Extensions/TimeInterval+ExpectationTimeout.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension TimeInterval {
+    static let expectationTimeout: TimeInterval = 5
+}

--- a/Tests/Spies/BridgeDelegateSpy.swift
+++ b/Tests/Spies/BridgeDelegateSpy.swift
@@ -49,7 +49,7 @@ final class BridgeDelegateSpy: BridgingDelegate {
         return nil
     }
     
-    func bridgeDidInitialize() async throws {
+    func bridgeDidInitialize() {
         
     }
     

--- a/Tests/Spies/BridgeSpy.swift
+++ b/Tests/Spies/BridgeSpy.swift
@@ -9,7 +9,15 @@ final class BridgeSpy: Bridgable {
     var registerComponentWasCalled = false
     var registerComponentArg: String? = nil
     
-    var registerComponentsWasCalled = false
+    var registerComponentsWasCalled = false {
+        didSet {
+            if registerComponentsWasCalled {
+                registerComponentsContinuation?.resume()
+                registerComponentsContinuation = nil
+            }
+        }
+    }
+    var registerComponentsContinuation: CheckedContinuation<Void, Never>?
     var registerComponentsArg: [String]? = nil
     
     var unregisterComponentWasCalled = false


### PR DESCRIPTION
This PR ensures all classes and functions are thread-safe by adopting the `@MainActor` attribute.

With the adoption of async/await we've introduces potential race conditions and made some of the classes not thread safe.
A `MainActor` is a globally unique actor who performs his tasks on the main thread. 

I think adopting MainActor makes sense because:
- it ensures thread safety throughout the library.
- `BridgeDelegate` is usually instantiated in a `UIViewController`, which conforms to `MainActor` itself, thus no additional code changes are needed.
- `BridgeComponent`s are usually used to interact with UI, which must run on the main thread.

This PR also fixes an error when using the async version of `evaluateJavaScript`. More info [here](https://forums.developer.apple.com/forums/thread/701553).