### PR TITLE
Update BridgeComponent extension example

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -11,7 +11,7 @@ For now, create an empty (global) list of registered component factories, so we 
 **`BridgeComponent+App.swift`**
 ```swift
 extension BridgeComponent {
-    static var allTypes: [BridgeComponent.Type] {
+    nonisolated static var allTypes: [BridgeComponent.Type] {
         [
             // Add registered components here later
         ]


### PR DESCRIPTION
This adds a small change to the quick start guide documentation to use `nonisolated` keyword to avoid errors on new Xcode apps

https://github.com/hotwired/strada-ios/issues/34

