### PR TITLE
Allow Strada components to connect when loaded on a background tab

### DIFF
--- a/Source/BridgeDelegate.swift
+++ b/Source/BridgeDelegate.swift
@@ -124,8 +124,13 @@ public final class BridgeDelegate: BridgingDelegate {
     
     @discardableResult
     public func bridgeDidReceiveMessage(_ message: Message) -> Bool {
-        guard destinationIsActive,
-              resolvedLocation == message.metadata?.url else {
+        if message.event != "connect" {
+            guard destinationIsActive else {
+                logger.warning("bridgeDidIgnoreMessage because destination was inactive: \(String(describing: message))")
+                return false
+            }
+        }
+        guard resolvedLocation == message.metadata?.url else {
             logger.warning("bridgeDidIgnoreMessage: \(String(describing: message))")
             return false
         }


### PR DESCRIPTION
This fixes #33 

The basic change here is not ignoring the `connect` event even if the page is not yet active.  
The issue with ignoring the `connect` event is that when the page becomes active, the web view has already fired it's connect event and the component isn't initialized.